### PR TITLE
Fix none type error in start function

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -157,7 +157,8 @@ class SaveMeBot:
             [KeyboardButton("⚙️ הגדרות")]
         ]
         reply_markup = ReplyKeyboardMarkup(keyboard, resize_keyboard=True)
-        await update.message.reply_text(welcome_text, reply_markup=reply_markup)
+        chat_id = update.effective_chat.id
+        await context.bot.send_message(chat_id=chat_id, text=welcome_text, reply_markup=reply_markup)
         return SELECTING_ACTION
 
     async def ask_for_content(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:


### PR DESCRIPTION
Fixes `AttributeError` when `update.message` is `None` by using `context.bot.send_message`.

---
<a href="https://cursor.com/background-agent?bcId=bc-08333a7f-0eb2-4f82-a3a1-d9e62e636fb6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-08333a7f-0eb2-4f82-a3a1-d9e62e636fb6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

