### PR TITLE
Display all content as code block

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -25,3 +25,5 @@ services:
         value: 168
       - key: MIN_REMINDER_HOURS
         value: 1
+      - key: FORCE_CODE_BLOCKS
+        value: true


### PR DESCRIPTION
Add `FORCE_CODE_BLOCKS` flag to wrap all bot responses in fenced code blocks.

This change was requested by the user to ensure all textual content is presented as code, improving readability for code-like output. The flag is enabled by default in `render.yaml`.

---
<a href="https://cursor.com/background-agent?bcId=bc-aceaa38e-3db2-4f95-9e53-370187bd3983">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-aceaa38e-3db2-4f95-9e53-370187bd3983">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

