### PR TITLE
Fix code block display issue

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -122,6 +122,13 @@ def format_text_content_for_telegram(text: str):
             fence = f"```{lang}\n{text}\n```"
             return fence, ParseMode.MARKDOWN_V2
 
+        # If content contains fenced code markers anywhere, prefer MarkdownV2 so Telegram renders blocks
+        try:
+            if text.count('```') >= 2:
+                return text, ParseMode.MARKDOWN_V2
+        except Exception:
+            pass
+
         if is_fenced_code_block(text):
             # Proper fenced code block: use MarkdownV2 to get native code UI
             return text, ParseMode.MARKDOWN_V2
@@ -148,7 +155,7 @@ def format_text_content_for_telegram(text: str):
         if any(re.search(pattern, text) for pattern in code_patterns):
             lang = detect_code_language(text) or ''
             fence = f"```{lang}\n{text}\n```"
-            return fence, ParseMode.MARKDOWN
+            return fence, ParseMode.MARKDOWN_V2
 
         return text, None
     except Exception:


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Ensure fenced code blocks and code-like content are rendered correctly by consistently using MarkdownV2.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
Previously, content containing triple backticks (` ``` `) was not consistently displayed as code blocks in Telegram because the incorrect `ParseMode` was being applied. This change forces `ParseMode.MARKDOWN_V2` when backticks are detected or when content is identified as code-like, ensuring proper rendering.

---
<a href="https://cursor.com/background-agent?bcId=bc-568f4f23-24bb-4f69-9231-acbc84ad9305">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-568f4f23-24bb-4f69-9231-acbc84ad9305">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

