### PR TITLE
Fix gist creation and editing errors

### DIFF
--- a/src/database/database_manager.py
+++ b/src/database/database_manager.py
@@ -134,6 +134,10 @@ class Database:
         except Exception as e:
             logger.error(f"Error getting item {item_id}: {e}")
             return None
+
+    def get_item_by_id(self, item_id: int) -> Optional[Dict[str, Any]]:
+        """Alias לשמירה על תאימות לאחור: קבלת פריט לפי ID"""
+        return self.get_item(item_id)
     
     def get_user_categories(self, user_id: int) -> List[str]:
         """קבלת רשימת קטגוריות של משתמש"""

--- a/src/github_gist_handler.py
+++ b/src/github_gist_handler.py
@@ -73,16 +73,16 @@ class GithubGistHandler:
                 return {"error": "GitHub token not configured. Use /setup_github first."}
             
             # Get item from database
-            item = self.db.get_item_by_id(item_id)
+            item = self.db.get_item(item_id)
             if not item or item['user_id'] != user_id:
                 return {"error": "Item not found or access denied."}
             
-            # Check if item is code/text
-            if item['content_type'] not in ['text', 'code']:
-                return {"error": "Only text and code items can be converted to Gists."}
+            # Ensure item has textual content
+            content = (item.get('content') or '').strip()
+            if not content:
+                return {"error": "Only items with textual content can be converted to Gists."}
             
             # Prepare gist content
-            content = item['content']
             filename = self._generate_filename(item)
             
             # Use item subject as description if not provided


### PR DESCRIPTION
Fix file editing and Gist creation by correcting database update arguments, adding a missing database method, and hardening Markdown parsing.

The bot was failing to edit files due to an incorrect `file_data` argument in `update_content` and Gist creation was getting stuck on "⏳ יוצר Gist..." because of Telegram Markdown parsing errors and a missing `get_item_by_id` method. This PR resolves these issues and ensures Gists are only created for textual content.

---
<a href="https://cursor.com/background-agent?bcId=bc-6973b194-3951-44c7-83bf-f7f564ec5e0e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-6973b194-3951-44c7-83bf-f7f564ec5e0e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

