### PR TITLE
Fix gist creation character parsing

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -1178,22 +1178,42 @@ class SaveMeBot:
             safe_url = escape_markdown(gist_url)
             safe_visibility = escape_markdown(visibility)
             
-            await query.edit_message_text(
-                "✅ **Gist נוצר בהצלחה!**\n\n"
-                f"📝 קובץ: {safe_filename}\n"
-                f"🔐 סוג: {safe_visibility}\n"
-                f"🔗 קישור: {safe_url}\n\n"
-                "הקישור נשמר עם הפריט.",
-                reply_markup=InlineKeyboardMarkup(keyboard),
-                parse_mode=ParseMode.MARKDOWN_V2
-            )
+            try:
+                await query.edit_message_text(
+                    "✅ **Gist נוצר בהצלחה\!**\n\n"
+                    f"📝 קובץ: {safe_filename}\n"
+                    f"🔐 סוג: {safe_visibility}\n"
+                    f"🔗 קישור: {safe_url}\n\n"
+                    "הקישור נשמר עם הפריט.",
+                    reply_markup=InlineKeyboardMarkup(keyboard),
+                    parse_mode=ParseMode.MARKDOWN_V2
+                )
+            except BadRequest:
+                html_filename = html.escape(result.get('filename', 'file'))
+                html_url = html.escape(gist_url)
+                html_visibility = html.escape(visibility)
+                await query.edit_message_text(
+                    "✅ <b>Gist נוצר בהצלחה!</b>\n\n"
+                    f"📝 קובץ: {html_filename}\n"
+                    f"🔐 סוג: {html_visibility}\n"
+                    f"🔗 קישור: {html_url}\n\n"
+                    "הקישור נשמר עם הפריט.",
+                    reply_markup=InlineKeyboardMarkup(keyboard),
+                    parse_mode=ParseMode.HTML
+                )
         else:
             error_msg = result.get('error', 'שגיאה לא ידועה') if result else 'שגיאה לא ידועה'
             safe_error = escape_markdown(str(error_msg))
-            await query.edit_message_text(
-                "❌ **שגיאה ביצירת Gist:**\n" + safe_error,
-                parse_mode=ParseMode.MARKDOWN_V2
-            )
+            try:
+                await query.edit_message_text(
+                    "❌ **שגיאה ביצירת Gist:**\n" + safe_error,
+                    parse_mode=ParseMode.MARKDOWN_V2
+                )
+            except BadRequest:
+                await query.edit_message_text(
+                    "❌ <b>שגיאה ביצירת Gist:</b>\n" + html.escape(str(error_msg)),
+                    parse_mode=ParseMode.HTML
+                )
         
         del context.user_data['gist_item_id']
         return await self.start(update, context)


### PR DESCRIPTION
Escape MarkdownV2 special characters and add HTML fallback to prevent `BadRequest` errors when sending messages.

The bot was failing to send messages containing unescaped MarkdownV2 special characters (like '!') in `handle_gist_confirm`, leading to `BadRequest` errors and the bot getting stuck. This change ensures messages are correctly parsed by Telegram, either through proper MarkdownV2 escaping or by falling back to HTML.

---
<a href="https://cursor.com/background-agent?bcId=bc-ff4ea12b-71bd-4fe9-9bfa-d5a5e21f4114">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-ff4ea12b-71bd-4fe9-9bfa-d5a5e21f4114">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

