### PR TITLE
Add markdown export button

### DIFF
--- a/src/database/database_manager.py
+++ b/src/database/database_manager.py
@@ -698,3 +698,33 @@ class Database:
         except Exception as e:
             logger.error(f"Error getting item share info: {e}")
             return None
+    
+    def get_all_user_items(self, user_id: int) -> List[Dict[str, Any]]:
+        """מחזיר את כל הפריטים של המשתמש"""
+        try:
+            with sqlite3.connect(self.db_path) as conn:
+                conn.row_factory = sqlite3.Row
+                cursor = conn.cursor()
+                cursor.execute('''
+                    SELECT * FROM saved_items 
+                    WHERE user_id = ? 
+                    ORDER BY is_pinned DESC, created_at DESC
+                ''', (user_id,))
+                return [dict(row) for row in cursor.fetchall()]
+        except Exception as e:
+            logger.error(f"Error getting all user items: {e}")
+            return []
+    
+    def get_user_items_count(self, user_id: int) -> int:
+        """מחזיר את מספר הפריטים של המשתמש"""
+        try:
+            with sqlite3.connect(self.db_path) as conn:
+                cursor = conn.cursor()
+                cursor.execute('''
+                    SELECT COUNT(*) FROM saved_items 
+                    WHERE user_id = ?
+                ''', (user_id,))
+                return cursor.fetchone()[0]
+        except Exception as e:
+            logger.error(f"Error getting user items count: {e}")
+            return 0

--- a/src/main.py
+++ b/src/main.py
@@ -22,6 +22,7 @@ from database.database_manager import Database
 from activity_reporter import create_reporter
 from github_gist_handler import GithubGistHandler
 from internal_share_handler import InternalShareHandler
+from markdown_exporter import MarkdownExporter
 
 # Activity Reporter setup (keep after variable loading)
 reporter = create_reporter(
@@ -232,6 +233,7 @@ class SaveMeBot:
         self.db = Database(db_path=db_path)
         self.gist_handler = GithubGistHandler(self.db)
         self.share_handler = InternalShareHandler(self.db)
+        self.markdown_exporter = MarkdownExporter()
         self._start_reminder_job = False
 
     async def reminder_hours_input(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
@@ -413,7 +415,8 @@ class SaveMeBot:
         welcome_text = f"שלום {username}! 👋\nברוך הבא לבוט 'שמור לי'.\nבחר פעולה מהתפריט:"
         keyboard = [
             [KeyboardButton("➕ הוסף תוכן"), KeyboardButton("🧩 איסוף טקסט רב-הודעות")],
-            [KeyboardButton("🔍 חיפוש"), KeyboardButton("📚 הצג קטגוריות")]
+            [KeyboardButton("🔍 חיפוש"), KeyboardButton("📚 הצג קטגוריות")],
+            [KeyboardButton("📤 ייצוא לMarkdown")]
         ]
         reply_markup = ReplyKeyboardMarkup(keyboard, resize_keyboard=True)
         chat_id = update.effective_chat.id
@@ -652,8 +655,9 @@ class SaveMeBot:
             content_buttons_row_gist_share.append(InlineKeyboardButton("צור קישור פנימי 🔗", callback_data=f"share_{item_id}"))
             content_buttons_row_gist_share.append(InlineKeyboardButton("Gist 🐙", callback_data=f"gist_{item_id}"))
 
-            # Download row (copy all removed per request)
+            # Download row with markdown export
             content_buttons_row_copy_download.append(InlineKeyboardButton("📥 הורדה", callback_data=f"download_{item_id}"))
+            content_buttons_row_copy_download.append(InlineKeyboardButton("📝 ייצוא MD", callback_data=f"export_md_{item_id}"))
         elif content_type == 'document' and file_id:
             content_buttons_row_copy_download.append(InlineKeyboardButton("📥 הורדה", callback_data=f"download_{item_id}"))
 
@@ -1026,6 +1030,10 @@ class SaveMeBot:
         # Handle unshare
         if action.startswith('unshare'):
             return await self.handle_unshare(update, context)
+        
+        # Handle markdown export for single item
+        if action.startswith('export_md'):
+            return await self.handle_markdown_export(update, context)
 
         context.user_data['action_item_id'] = item_id
         if action == 'note': await query.edit_message_text("הקלד את ההערה:"); return AWAIT_NOTE
@@ -1201,8 +1209,8 @@ class SaveMeBot:
         await query.edit_message_text(
             "🐙 **יצירת GitHub Gist**\n\n"
             "האם ברצונך ליצור Gist ציבורי או פרטי?\n\n"
-            "• **ציבורי** \- כל אחד יכול לראות \(מופיע בחיפוש\)\n"
-            "• **פרטי** \- רק מי שיש לו את הקישור",
+            "• **ציבורי** \\- כל אחד יכול לראות \\(מופיע בחיפוש\\)\n"
+            "• **פרטי** \\- רק מי שיש לו את הקישור",
             reply_markup=InlineKeyboardMarkup(keyboard),
             parse_mode=ParseMode.MARKDOWN_V2
         )
@@ -1244,7 +1252,7 @@ class SaveMeBot:
             
             try:
                 await query.edit_message_text(
-                    "✅ **Gist נוצר בהצלחה\!**\n\n"
+                    "✅ **Gist נוצר בהצלחה\\!**\n\n"
                     f"📝 קובץ: {safe_filename}\n"
                     f"🔐 סוג: {safe_visibility}\n"
                     f"🔗 קישור: {safe_url}\n\n"
@@ -1282,6 +1290,100 @@ class SaveMeBot:
         del context.user_data['gist_item_id']
         return await self.start(update, context)
     
+    async def handle_markdown_export(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
+        """טיפול בייצוא פריט לMarkdown"""
+        query = update.callback_query
+        await query.answer()
+        
+        # Extract item ID from callback data
+        data = query.data
+        
+        if data.startswith('export_md_'):
+            # ייצוא פריט בודד
+            item_id = int(data.replace('export_md_', ''))
+            item = self.db.get_item(item_id)
+            
+            if not item:
+                await query.edit_message_text("❌ הפריט לא נמצא.")
+                return SELECTING_ACTION
+            
+            # יצירת Markdown
+            user_info = {'username': update.effective_user.first_name}
+            markdown_content = self.markdown_exporter.export_single_item_to_markdown(item)
+            
+            # יצירת קובץ
+            filename = f"{item.get('subject', 'item')}-{datetime.now(tz=LOCAL_TZ).strftime('%Y%m%d-%H%M%S')}.md"
+            md_file = self.markdown_exporter.create_markdown_file(markdown_content, filename)
+            
+            # שליחת הקובץ
+            await context.bot.send_document(
+                chat_id=query.message.chat.id,
+                document=md_file,
+                filename=filename,
+                caption=f"📝 **יוצא לMarkdown:** {item.get('subject', 'פריט')}\n"
+                        f"📁 **קטגוריה:** {item.get('category', 'כללי')}"
+            )
+            
+            await query.answer("✅ הפריט יוצא בהצלחה לMarkdown")
+            
+        elif data == 'export_all_md':
+            # ייצוא כל הפריטים
+            user_id = update.effective_user.id
+            all_items = self.db.get_all_user_items(user_id)
+            
+            if not all_items:
+                await query.edit_message_text("❌ אין פריטים לייצוא.")
+                return SELECTING_ACTION
+            
+            await query.edit_message_text("⏳ מייצא את כל הפריטים לMarkdown...")
+            
+            # יצירת Markdown
+            user_info = {'username': update.effective_user.first_name}
+            markdown_content = self.markdown_exporter.export_items_to_markdown(all_items, user_info)
+            
+            # יצירת קובץ
+            filename = f"all-items-{datetime.now(tz=LOCAL_TZ).strftime('%Y%m%d-%H%M%S')}.md"
+            md_file = self.markdown_exporter.create_markdown_file(markdown_content, filename)
+            
+            # שליחת הקובץ
+            await context.bot.send_document(
+                chat_id=query.message.chat.id,
+                document=md_file,
+                filename=filename,
+                caption=f"📚 **יוצאו {len(all_items)} פריטים לMarkdown**\n"
+                        f"הקובץ כולל תוכן עניינים, סטטיסטיקות וכל הפריטים השמורים."
+            )
+            
+            await query.answer("✅ כל הפריטים יוצאו בהצלחה")
+            
+        return SELECTING_ACTION
+    
+    async def ask_for_markdown_export(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
+        """שואל את המשתמש מה לייצא לMarkdown"""
+        self._report(update)
+        
+        user_id = update.effective_user.id
+        items_count = self.db.get_user_items_count(user_id)
+        
+        if items_count == 0:
+            await update.message.reply_text("❌ אין לך פריטים שמורים לייצוא.")
+            return await self.start(update, context)
+        
+        keyboard = [
+            [InlineKeyboardButton(f"📚 ייצא הכל ({items_count} פריטים)", callback_data="export_all_md")],
+            [InlineKeyboardButton("📁 בחר קטגוריה", callback_data="export_category_md")],
+            [InlineKeyboardButton("❌ ביטול", callback_data="cancel")]
+        ]
+        
+        await update.message.reply_text(
+            "📝 **ייצוא לMarkdown**\n\n"
+            "מה תרצה לייצא?",
+            reply_markup=InlineKeyboardMarkup(keyboard),
+            parse_mode=ParseMode.MARKDOWN
+        )
+        
+        return SELECTING_ACTION
+
     async def handle_share_creation(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
         """טיפול ביצירת קישור פנימי לשיתוף"""
         query = update.callback_query
@@ -1309,7 +1411,7 @@ class SaveMeBot:
             safe_url = escape_markdown(share_url)
             
             await query.edit_message_text(
-                f"📤 **קישור שיתוף פנימי קיים\!**\n\n"
+                f"📤 **קישור שיתוף פנימי קיים\\!**\n\n"
                 f"הפריט כבר משותף בקישור:\n"
                 f"```\n{safe_url}\n```\n"
                 f"ניתן לפתוח את הקישור או להסיר את השיתוף.",
@@ -1333,11 +1435,11 @@ class SaveMeBot:
                 safe_url = escape_markdown(share_url)
                 
                 await query.edit_message_text(
-                    f"✅ **קישור שיתוף פנימי נוצר בהצלחה\!**\n\n"
+                    f"✅ **קישור שיתוף פנימי נוצר בהצלחה\\!**\n\n"
                     f"📤 הקישור לשיתוף:\n"
                     f"```\n{safe_url}\n```\n"
-                    f"שתף את הקישור עם כל מי שתרצה\!\n"
-                    f"הם יוכלו לצפות בתוכן ולהעתיק אותו\.",
+                    f"שתף את הקישור עם כל מי שתרצה\\!\n"
+                    f"הם יוכלו לצפות בתוכן ולהעתיק אותו\\.",
                     parse_mode=ParseMode.MARKDOWN_V2,
                     reply_markup=reply_markup
                 )
@@ -1541,11 +1643,13 @@ def main() -> None:
                 MessageHandler(filters.TEXT & filters.Regex('^🧩 איסוף טקסט רב-הודעות$'), bot.start_multipart),
                 MessageHandler(filters.TEXT & filters.Regex('^🔍 חיפוש$'), bot.ask_for_search_query),
                 MessageHandler(filters.TEXT & filters.Regex('^📚 הצג קטגוריות$'), bot.show_categories),
+                MessageHandler(filters.TEXT & filters.Regex('^📤 ייצוא לMarkdown$'), bot.ask_for_markdown_export),
                 # Removed settings from main menu
                 CallbackQueryHandler(bot.show_category_items, pattern="^showcat_"),
                 CallbackQueryHandler(bot.upload_router, pattern="^(upload_start_multipart|upload_close)$"),
-                CallbackQueryHandler(bot.item_action_router, pattern="^(showitem_|pin_|delete_|note_|edit_|editsubject_|preview_|download_|reminder_|remset_|remdate_|remcustom_|remclear_|remignore_|gist_|share_|unshare_|back_categories)" ),
+                CallbackQueryHandler(bot.item_action_router, pattern="^(showitem_|pin_|delete_|note_|edit_|editsubject_|preview_|download_|reminder_|remset_|remdate_|remcustom_|remclear_|remignore_|gist_|share_|unshare_|back_categories|export_md_)" ),
                 CallbackQueryHandler(bot.handle_shared_item_action, pattern="^(copy_shared_|download_shared_|main_menu)"),
+                CallbackQueryHandler(bot.handle_markdown_export, pattern="^(export_all_md|export_category_md)$"),
                 CallbackQueryHandler(bot.handle_github_action, pattern="^(github_replace|github_remove|cancel|setup_github_now)$"),
                 CallbackQueryHandler(bot.calendar_router, pattern="^(cal_|calpick_|time_|time_custom|remcancel_)"),
             ],

--- a/src/markdown_exporter.py
+++ b/src/markdown_exporter.py
@@ -1,0 +1,342 @@
+"""
+מודול לייצוא פריטים שמורים לפורמט Markdown
+כולל עיצוב מתקדם, סטטיסטיקות, ותוכן עניינים
+"""
+
+import re
+from datetime import datetime
+from zoneinfo import ZoneInfo
+from typing import List, Dict, Any, Optional
+from io import BytesIO
+import logging
+
+logger = logging.getLogger(__name__)
+
+class MarkdownExporter:
+    """מחלקה לייצוא פריטים לפורמט Markdown"""
+    
+    def __init__(self, timezone: str = 'Asia/Jerusalem'):
+        self.timezone = ZoneInfo(timezone)
+        self.language_icons = {
+            'python': '🐍',
+            'javascript': '🟨', 
+            'java': '☕',
+            'cpp': '⚡',
+            'c': '🔧',
+            'html': '🌐',
+            'css': '🎨',
+            'sql': '🗃️',
+            'bash': '💻',
+            'json': '📋',
+            'yaml': '📄',
+            'markdown': '📝',
+            'go': '🐹',
+            'rust': '🦀',
+            'php': '🐘',
+            'ruby': '💎',
+            'typescript': '🔷',
+            'swift': '🦉',
+            'kotlin': '🟣',
+            'dockerfile': '🐳',
+            'xml': '📰',
+            'ini': '⚙️',
+            'toml': '🔧',
+            'csharp': '🔵'
+        }
+    
+    def get_language_icon(self, language: str) -> str:
+        """מחזיר אייקון לשפת תכנות"""
+        if not language:
+            return '📄'
+        return self.language_icons.get(language.lower(), '📄')
+    
+    def detect_code_language(self, text: str) -> Optional[str]:
+        """זיהוי אוטומטי של שפת התכנות בטקסט"""
+        try:
+            sample = text.strip()
+            if not sample:
+                return None
+                
+            first_line = sample.splitlines()[0] if sample else ""
+            
+            # Shebang detection
+            if re.match(r'^#!/bin/(bash|sh)', sample):
+                return 'bash'
+            if re.match(r'^#!/usr/bin/env python', sample):
+                return 'python'
+            if re.match(r'^#!/usr/bin/env node', sample):
+                return 'javascript'
+                
+            # Language-specific patterns
+            if '<?php' in sample:
+                return 'php'
+            if re.search(r'</?[a-zA-Z][\w:-]*\b', sample) and '<' in sample and '>' in sample:
+                return 'html'
+            if re.search(r'^\s*\{', sample) and re.search(r'"[^"]+"\s*:', sample):
+                return 'json'
+            if re.search(r'^(FROM|RUN|CMD|COPY|ENTRYPOINT|ENV|ARG|WORKDIR|EXPOSE)\b', sample, re.IGNORECASE | re.MULTILINE):
+                return 'dockerfile'
+            if re.search(r'^\s*\[.+\]\s*$', sample, re.MULTILINE) and re.search(r'=', sample):
+                return 'ini'
+            if re.search(r'^[\s\-\w]+:\s+.+$', sample, re.MULTILINE) and not re.search(r';\s*$', sample, re.MULTILINE):
+                return 'yaml'
+            if re.search(r'\bpackage\s+main\b', sample) or re.search(r'\bfunc\s+\w+\s*\(', sample):
+                return 'go'
+            if re.search(r'\bfn\s+\w+\s*\(|println!\s*\(', sample):
+                return 'rust'
+            if re.search(r'\busing\s+System\b|\bnamespace\b|public\s+class\b', sample):
+                return 'csharp'
+            if re.search(r'\bpublic\s+class\b|System\.out\.println', sample):
+                return 'java'
+            if re.search(r'\bSELECT\b|\bINSERT\b|\bUPDATE\b|\bDELETE\b|\bCREATE\b|\bTABLE\b', sample, re.IGNORECASE):
+                return 'sql'
+            if re.search(r'\b(def|class)\s+\w+|from\s+\w+\s+import|import\s+\w+', sample) and not re.search(r';\s*$', first_line):
+                return 'python'
+            if re.search(r'\b(const|let|var|function)\b|=>|console\.log|import\s+.*\s+from\s+', sample):
+                return 'javascript'
+            if re.search(r'\b(interface|type|namespace|declare)\b|:\s*(string|number|boolean)', sample):
+                return 'typescript'
+                
+            return None
+        except Exception:
+            return None
+    
+    def generate_header(self, user_info: Dict[str, Any], items_count: int) -> str:
+        """יוצר כותרת מעוצבת למסמך"""
+        date = datetime.now(tz=self.timezone).strftime('%d/%m/%Y')
+        time = datetime.now(tz=self.timezone).strftime('%H:%M')
+        username = user_info.get('username', 'משתמש')
+        
+        header = f"""# 📚 אוסף הקוד והתוכן השמור
+
+> **נוצר בתאריך:** {date} בשעה {time}  
+> **משתמש:** {username}  
+> **סך הכל פריטים:** {items_count}
+
+---
+
+"""
+        return header
+    
+    def generate_table_of_contents(self, items: List[Dict[str, Any]]) -> str:
+        """יוצר תוכן עניינים אוטומטי"""
+        toc = "## 📑 תוכן עניינים\n\n"
+        
+        # קיבוץ לפי קטגוריה
+        categories = {}
+        for idx, item in enumerate(items, 1):
+            category = item.get('category', 'כללי')
+            if category not in categories:
+                categories[category] = []
+            categories[category].append((idx, item))
+        
+        # יצירת תוכן עניינים לפי קטגוריות
+        for category, category_items in categories.items():
+            toc += f"### 📁 {category}\n"
+            for idx, item in category_items:
+                subject = item.get('subject', f'פריט #{idx}')
+                # יצירת anchor link
+                anchor = f"פריט-{idx}---{self.sanitize_anchor(subject)}"
+                toc += f"- [{subject}](#{anchor})\n"
+            toc += "\n"
+        
+        toc += "---\n\n"
+        return toc
+    
+    def sanitize_anchor(self, text: str) -> str:
+        """מנקה טקסט לשימוש כ-anchor בMarkdown"""
+        # החלפת תווים בעייתיים
+        text = re.sub(r'[^\w\s\u0590-\u05FF-]', '', text)  # שומר על עברית
+        text = text.replace(' ', '-')
+        text = text.lower()
+        return text
+    
+    def generate_statistics(self, items: List[Dict[str, Any]]) -> str:
+        """יוצר סטטיסטיקות על האוסף"""
+        stats = "## 📊 סטטיסטיקות\n\n"
+        
+        # ספירת פריטים לפי קטגוריה
+        category_counts = {}
+        language_counts = {}
+        total_chars = 0
+        
+        for item in items:
+            # קטגוריות
+            category = item.get('category', 'כללי')
+            category_counts[category] = category_counts.get(category, 0) + 1
+            
+            # שפות תכנות (אם זה קוד)
+            content = item.get('content', '')
+            if content:
+                total_chars += len(content)
+                lang = self.detect_code_language(content)
+                if lang:
+                    language_counts[lang] = language_counts.get(lang, 0) + 1
+        
+        # טבלת קטגוריות
+        stats += "### 📂 התפלגות לפי קטגוריות\n\n"
+        stats += "| קטגוריה | מספר פריטים | אחוז |\n"
+        stats += "|---------|-------------|------|\n"
+        
+        total = len(items)
+        for category, count in sorted(category_counts.items(), key=lambda x: x[1], reverse=True):
+            percentage = (count / total * 100) if total > 0 else 0
+            stats += f"| {category} | {count} | {percentage:.1f}% |\n"
+        
+        # טבלת שפות תכנות (אם יש)
+        if language_counts:
+            stats += "\n### 💻 שפות תכנות שזוהו\n\n"
+            stats += "| שפה | אייקון | מספר קטעים |\n"
+            stats += "|-----|--------|------------|\n"
+            
+            for lang, count in sorted(language_counts.items(), key=lambda x: x[1], reverse=True):
+                icon = self.get_language_icon(lang)
+                stats += f"| {lang.title()} | {icon} | {count} |\n"
+        
+        # סטטיסטיקות כלליות
+        stats += f"\n### 📈 נתונים כלליים\n\n"
+        stats += f"- **סך הכל תווים:** {total_chars:,}\n"
+        stats += f"- **ממוצע תווים לפריט:** {total_chars // total if total > 0 else 0:,}\n"
+        stats += f"- **פריטים מוצמדים:** {sum(1 for item in items if item.get('is_pinned', False))}\n"
+        
+        # תגיות פופולריות (אם יש)
+        all_tags = []
+        for item in items:
+            if item.get('tags'):
+                all_tags.extend(item['tags'])
+        
+        if all_tags:
+            from collections import Counter
+            tag_counts = Counter(all_tags)
+            top_tags = tag_counts.most_common(10)
+            
+            stats += "\n### 🏷️ תגיות פופולריות\n\n"
+            stats += " • ".join([f"`{tag}` ({count})" for tag, count in top_tags])
+            stats += "\n"
+        
+        stats += "\n---\n\n"
+        return stats
+    
+    def format_single_item(self, item: Dict[str, Any], index: int) -> str:
+        """מעצב פריט בודד לMarkdown"""
+        subject = item.get('subject', f'פריט #{index}')
+        category = item.get('category', 'כללי')
+        content = item.get('content', '')
+        note = item.get('note', '')
+        created_at = item.get('created_at', '')
+        
+        # כותרת הפריט
+        section = f"## פריט {index} - {subject}\n\n"
+        
+        # מטא-דאטה
+        section += f"📁 **קטגוריה:** {category}  \n"
+        
+        if created_at:
+            try:
+                date = datetime.fromisoformat(created_at)
+                formatted_date = date.strftime('%d/%m/%Y %H:%M')
+                section += f"📅 **נוצר:** {formatted_date}  \n"
+            except:
+                pass
+        
+        # תגיות (אם יש)
+        if item.get('tags'):
+            tags_str = ', '.join([f"`{tag}`" for tag in item['tags']])
+            section += f"🏷️ **תגיות:** {tags_str}  \n"
+        
+        # סימון פריט מוצמד
+        if item.get('is_pinned'):
+            section += "📌 **פריט מוצמד**  \n"
+        
+        # הערה (אם יש)
+        if note:
+            section += f"\n💡 **הערה:**\n> {note}\n"
+        
+        section += "\n"
+        
+        # התוכן עצמו
+        if content:
+            content_type = item.get('content_type', 'text')
+            
+            if content_type == 'text' or content_type == 'document':
+                # זיהוי שפת תכנות
+                language = self.detect_code_language(content) or ''
+                lang_icon = self.get_language_icon(language) if language else ''
+                
+                if language:
+                    section += f"### {lang_icon} קוד ({language.title()})\n\n"
+                else:
+                    section += "### 📝 תוכן\n\n"
+                
+                # הוספת התוכן בבלוק קוד
+                section += f"```{language}\n{content}\n```\n"
+            else:
+                # לסוגי תוכן אחרים (תמונה, וידאו וכו')
+                file_name = item.get('file_name', '')
+                if file_name:
+                    section += f"### 📎 קובץ מצורף: {file_name}\n\n"
+                    if item.get('caption'):
+                        section += f"> {item['caption']}\n\n"
+        
+        # קישורים (אם יש)
+        if item.get('gist_url'):
+            section += f"\n🔗 **GitHub Gist:** [{item['gist_url']}]({item['gist_url']})\n"
+        
+        section += "\n---\n\n"
+        return section
+    
+    def export_items_to_markdown(self, items: List[Dict[str, Any]], user_info: Dict[str, Any]) -> str:
+        """מייצא רשימת פריטים לפורמט Markdown מלא"""
+        if not items:
+            return "# אין פריטים לייצוא\n\nהאוסף ריק."
+        
+        markdown = ""
+        
+        # כותרת
+        markdown += self.generate_header(user_info, len(items))
+        
+        # תוכן עניינים
+        markdown += self.generate_table_of_contents(items)
+        
+        # סטטיסטיקות
+        markdown += self.generate_statistics(items)
+        
+        # הפריטים עצמם
+        markdown += "## 📚 הפריטים השמורים\n\n"
+        for idx, item in enumerate(items, 1):
+            markdown += self.format_single_item(item, idx)
+        
+        # סיום
+        markdown += self.generate_footer()
+        
+        return markdown
+    
+    def generate_footer(self) -> str:
+        """יוצר סיום למסמך"""
+        footer = """---
+
+<div align="center">
+
+📚 **נוצר על ידי SaveMe Bot**  
+🤖 בוט חכם לשמירה וארגון של קוד ותוכן
+
+</div>"""
+        return footer
+    
+    def export_single_item_to_markdown(self, item: Dict[str, Any]) -> str:
+        """מייצא פריט בודד לMarkdown"""
+        markdown = f"# {item.get('subject', 'פריט שמור')}\n\n"
+        markdown += self.format_single_item(item, 1)
+        return markdown
+    
+    def create_markdown_file(self, content: str, filename: Optional[str] = None) -> BytesIO:
+        """יוצר קובץ Markdown מהתוכן"""
+        if not filename:
+            timestamp = datetime.now(tz=self.timezone).strftime('%Y%m%d-%H%M%S')
+            filename = f"export-{timestamp}.md"
+        
+        # יצירת BytesIO object
+        md_bytes = BytesIO(content.encode('utf-8'))
+        md_bytes.name = filename
+        
+        return md_bytes


### PR DESCRIPTION
Add Markdown export functionality with dedicated buttons to allow users to export single items or their entire collection in a structured Markdown format.

---
<a href="https://cursor.com/background-agent?bcId=bc-08473f16-0d55-44e1-8d6c-45f902aa6e7b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-08473f16-0d55-44e1-8d6c-45f902aa6e7b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

